### PR TITLE
Use JavaFX official Gradle Plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,6 @@ buildscript {
         classpath(libs.com.android.tools.build.gradle)
         classpath(libs.org.jetbrains.kotlin.serialization.plugin)
         classpath(libs.com.squareup.sqldelight.gradle.plugin)
-        classpath(libs.com.google.osdetector.gradle.plugin)
         classpath(libs.org.jetbrains.kotlinx.atomicfu.plugin)
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,6 @@ org-jetbrains-kotlinx-serialization = "1.4.1"
 com-android-tools-build = "7.3.1"
 com-squareup-sqldelight = "1.5.3"
 com-diffplug-spotless = "6.11.0"
-com-google-osdetector = "1.7.1"
 # libraries
 io-ktor = "2.1.3"
 com-google-truth = "1.1.3"
@@ -34,7 +33,6 @@ org-jetbrains-kotlin-serialization-plugin = { module = "org.jetbrains.kotlin:kot
 org-jetbrains-kotlinx-atomicfu-plugin = { module = "org.jetbrains.kotlinx:atomicfu-gradle-plugin", version.ref = "org-jetbrains-kotlinx-atomicfu" }
 com-squareup-sqldelight-gradle-plugin = { module = "com.squareup.sqldelight:gradle-plugin", version.ref = "com-squareup-sqldelight" }
 com-diffplug-spotless-gradle-plugin = { module = "com.diffplug.spotless:spotless-plugin-gradle", version.ref = "com-diffplug-spotless" }
-com-google-osdetector-gradle-plugin = { module = "com.google.gradle:osdetector-gradle-plugin", version.ref = "com-google-osdetector" }
 
 # libraries
 io-ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "io-ktor" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -33,6 +33,7 @@ include(":ui:common")
 include(":ui:root")
 include(":ui:signed-in")
 include(":ui:signed-out")
+include(":ui:desktop-webview")
 
 include(":domain:timeline")
 include(":domain:authentication")

--- a/ui/desktop-webview/build.gradle.kts
+++ b/ui/desktop-webview/build.gradle.kts
@@ -1,0 +1,31 @@
+plugins {
+    kotlin("jvm")
+    id("org.jetbrains.compose")
+    id("social.androiddev.codequality")
+    id("org.openjfx.javafxplugin") version "0.0.13"
+}
+
+kotlin {
+    tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+        kotlinOptions.jvmTarget = "11"
+    }
+}
+
+dependencies {
+    implementation(compose.desktop.common)
+}
+
+javafx {
+    version = "19"
+    modules(
+        "javafx.base",
+        "javafx.controls",
+        "javafx.graphics",
+        "javafx.swing",
+        "javafx.web",
+        "javafx.media"
+    )
+
+}
+
+

--- a/ui/desktop-webview/src/main/kotlin/social/androiddev/ui/desktop/webview/JFXWebView.kt
+++ b/ui/desktop-webview/src/main/kotlin/social/androiddev/ui/desktop/webview/JFXWebView.kt
@@ -7,7 +7,7 @@
  *
  * You should have received a copy of the GNU General Public License along with Dodo. If not, see <https://www.gnu.org/licenses/>.
  */
-package social.androiddev.signedout.signin
+package social.androiddev.ui.desktop.webview
 
 import javafx.application.Platform
 import javafx.embed.swing.JFXPanel

--- a/ui/desktop-webview/src/main/kotlin/social/androiddev/ui/desktop/webview/WebView.kt
+++ b/ui/desktop-webview/src/main/kotlin/social/androiddev/ui/desktop/webview/WebView.kt
@@ -7,24 +7,29 @@
  *
  * You should have received a copy of the GNU General Public License along with Dodo. If not, see <https://www.gnu.org/licenses/>.
  */
-package social.androiddev.signedout.signin
+package social.androiddev.ui.desktop.webview
 
+import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import social.androiddev.ui.desktop.webview.JFXWebView
+import androidx.compose.ui.awt.SwingPanel
 
 @Composable
-actual fun SignInWebView(
-    modifier: Modifier,
+fun JFXWebView(
     url: String,
-    onWebError: (message: String) -> Unit,
-    onCancel: () -> Unit,
     shouldCancelLoadingUrl: (url: String) -> Boolean,
+    modifier: Modifier = Modifier
 ) {
-
-    JFXWebView(
+    SwingPanel(
+        background = MaterialTheme.colors.surface,
+        factory = {
+            JFXWebView(
+                url = url,
+                onUrlOfCurrentPageChanged = { url ->
+                    shouldCancelLoadingUrl(url)
+                },
+            )
+        },
         modifier = modifier,
-        url = url,
-        shouldCancelLoadingUrl = shouldCancelLoadingUrl
     )
 }

--- a/ui/signed-out/build.gradle.kts
+++ b/ui/signed-out/build.gradle.kts
@@ -1,7 +1,6 @@
 plugins {
     id("social.androiddev.library.ui")
     id("kotlin-parcelize")
-    id("com.google.osdetector")
 }
 
 android {
@@ -28,26 +27,11 @@ kotlin {
 
         val desktopMain by getting {
             dependencies {
-                //FIXME : Find the right way to use javafx in kotlin multiplatform project with android plugin
-                // https://stackoverflow.com/questions/73187027/use-javafx-in-kotlin-multiplatform
-                // As JavaFX have platform-specific dependencies, we need to add them manually
-                val fxSuffix = when (osdetector.classifier) {
-                    "linux-x86_64" -> "linux"
-                    "linux-aarch_64" -> "linux-aarch64"
-                    "windows-x86_64" -> "win"
-                    "osx-x86_64" -> "mac"
-                    "osx-aarch_64" -> "mac-aarch64"
-                    else -> throw IllegalStateException("Unknown OS: ${osdetector.classifier}")
-                }
-
-                implementation("org.openjfx:javafx-base:19:${fxSuffix}")
-                implementation("org.openjfx:javafx-graphics:19:${fxSuffix}")
-                implementation("org.openjfx:javafx-controls:19:${fxSuffix}")
-                implementation("org.openjfx:javafx-web:19:${fxSuffix}")
-                implementation("org.openjfx:javafx-swing:19:${fxSuffix}")
-                implementation("org.openjfx:javafx-media:19:${fxSuffix}")
+                implementation(compose.desktop.common)
+                implementation(projects.ui.desktopWebview)
 
             }
         }
     }
+
 }


### PR DESCRIPTION
## 📑 What does this PR do?

<!--- Please describe the changes in detail -->

We use JavaFX Desktop WebView in the user login Path. The integration of JavaFX is done with the official Gradle plugin. However, we can't use it in the same module as the Android Library plugin.

Firstly, We have put a workaround that consists of manually adding the necessary JavaFX dependencies depending on the machine running the build. Besides, normally the plugin official does the same things.

```
val fxSuffix = when (osdetector.classifier) {
    "linux-x86_64" -> "linux"
    "linux-aarch_64" -> "linux-aarch64"
    "windows-x86_64" -> "win"
    "osx-x86_64" -> "mac"
    "osx-aarch_64" -> "mac-aarch64"
    else -> throw IllegalStateException("Unknown OS: ${osdetector.classifier}")
}

implementation("org.openjfx:javafx-base:19:${fxSuffix}")
implementation("org.openjfx:javafx-graphics:19:${fxSuffix}")
implementation("org.openjfx:javafx-controls:19:${fxSuffix}")
implementation("org.openjfx:javafx-web:19:${fxSuffix}")
implementation("org.openjfx:javafx-swing:19:${fxSuffix}")
implementation("org.openjfx:javafx-media:19:${fxSuffix}")
```

So now, in this PR, to use the official JavaFX Gradle plugin, I created a new pure JVM module with a composable Webview based on the JavaFX Webview.


# ✅ Checklist

- [X] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [X] All the tests have passed

## 🧪 How can this PR been tested?


## 🧾 Tasks Remaining: (List of tasks remaining to be implemented)

-  Build and launch the login screen on Windows and Linux



## 🖼️ Screenshots (if applicable):
